### PR TITLE
Respond with a message for invalid connection request.

### DIFF
--- a/packages/la-boite/src/repos/intercept_request.spec.ts
+++ b/packages/la-boite/src/repos/intercept_request.spec.ts
@@ -1,0 +1,37 @@
+import { assertThat, throws, hasProperty, equalTo, matchesPattern, not } from 'hamjest'
+import {
+  validateRepoId,
+  checkForMissingRequestBodyContent,
+  InvalidRepoIdError,
+} from './intercept_request'
+
+describe('validateRepoId', () => {
+  it('does not throw InvalidRepoIdError when repoId is valid', async () =>
+    assertThat(() => validateRepoId('valid.id'), not(throws())))
+
+  it('throws InvalidRepoIdError when repoId is invalid', async () => {
+    assertThat(
+      () => validateRepoId('invalid/id'),
+      throws(hasProperty('message', equalTo(InvalidRepoIdError.message))),
+    )
+  })
+})
+
+describe('checkForMissingRequestBodyContent', () => {
+  it('does not throw an error when none of the expected parameters is missing', async () => {
+    const received = { repoId: 'id', remoteUrl: 'url' }
+    const expected = ['repoId', 'remoteUrl']
+
+    assertThat(() => checkForMissingRequestBodyContent({ received, expected }), not(throws()))
+  })
+
+  it('throws when one of the expected parameters is missing', async () => {
+    const received = {}
+    const expected = ['repoId', 'remoteUrl']
+
+    assertThat(
+      () => checkForMissingRequestBodyContent({ received, expected }),
+      throws(hasProperty('message', matchesPattern('Missing information from the request'))),
+    )
+  })
+})

--- a/packages/la-boite/src/repos/intercept_request.ts
+++ b/packages/la-boite/src/repos/intercept_request.ts
@@ -1,0 +1,68 @@
+import { Context } from 'koa'
+
+interface CheckForMissingRequestBodyContent {
+  ({ received, expected }: { received: unknown; expected: Array<string> }): void
+}
+
+interface InterceptRequestBody {
+  (ctx: Context, next: () => Promise<void>): void
+}
+
+interface RequestBodyContentHandlers {
+  [key: string]: (received: any) => void
+}
+
+interface ValidateRepoId {
+  (repoId: string): void
+}
+
+const InvalidRepoIdError = Error(
+  'Invalid repoId: We do not expect characters in repoId which must be url encoded.',
+)
+
+const checkForMissingRequestBodyContent: CheckForMissingRequestBodyContent = ({
+  received,
+  expected,
+}) => {
+  const missingRequestBodyContent = expected.filter(
+    (param: string) => !Object.keys(received).includes(param),
+  )
+  if (missingRequestBodyContent.length) {
+    throw Error(`Missing information from the request: ${missingRequestBodyContent.join(', ')}`)
+  }
+}
+
+const validateRepoId: ValidateRepoId = repoId => {
+  if (encodeURIComponent(repoId) !== repoId) {
+    throw InvalidRepoIdError
+  }
+}
+
+const requestBodyContentHandlers: RequestBodyContentHandlers = {
+  'POST/repos': received => {
+    checkForMissingRequestBodyContent({ received, expected: ['repoId', 'remoteUrl'] })
+    validateRepoId(received.repoId)
+  },
+}
+
+const interceptRequestBody: InterceptRequestBody = async (ctx, next) => {
+  const request = ctx.request
+  const handler = requestBodyContentHandlers[`${request.method + request.url}`]
+  if (handler) {
+    try {
+      handler(request.body)
+    } catch (error) {
+      ctx.status = 400
+      ctx.response.body = { error: error.message }
+      return
+    }
+  }
+  await next()
+}
+
+export {
+  interceptRequestBody,
+  validateRepoId,
+  checkForMissingRequestBodyContent,
+  InvalidRepoIdError,
+}

--- a/packages/la-boite/src/repos/repos_router.ts
+++ b/packages/la-boite/src/repos/repos_router.ts
@@ -2,9 +2,11 @@ import { Context } from 'koa'
 import Router from 'koa-router'
 import { ConnectRepoRequest } from './interfaces'
 import { Application } from '../application'
+import { interceptRequestBody } from './intercept_request'
 
 export function create({ repos }: Application): Router {
   const router = new Router({ prefix: '/repos' })
+  router.use(interceptRequestBody)
 
   router.get('repo', '/:repoId', async (ctx: Context) => {
     const { repoId } = ctx.params


### PR DESCRIPTION
Invalid request means when repoId is invalid or when something is missing from request body.
Related to issues 109 and 26