### PR TITLE
Add middleware to repos routes

### DIFF
--- a/packages/client-adapter-web/src/intercept_request.spec.ts
+++ b/packages/client-adapter-web/src/intercept_request.spec.ts
@@ -1,0 +1,37 @@
+import { assertThat, throws, hasProperty, equalTo, matchesPattern, not } from 'hamjest'
+import {
+  validateRepoId,
+  checkForMissingRequestBodyContent,
+  InvalidRepoIdError,
+} from './intercept_request'
+
+describe('validateRepoId', () => {
+  it('does not throw InvalidRepoIdError when repoId is valid', async () =>
+    assertThat(() => validateRepoId('valid.id'), not(throws())))
+
+  it('throws InvalidRepoIdError when repoId is invalid', async () => {
+    assertThat(
+      () => validateRepoId('invalid/id'),
+      throws(hasProperty('message', equalTo(InvalidRepoIdError.message))),
+    )
+  })
+})
+
+describe('checkForMissingRequestBodyContent', () => {
+  it('does not throw an error when none of the expected parameters is missing', async () => {
+    const received = { repoId: 'id', remoteUrl: 'url' }
+    const expected = ['repoId', 'remoteUrl']
+
+    assertThat(() => checkForMissingRequestBodyContent({ received, expected }), not(throws()))
+  })
+
+  it('throws when one of the expected parameters is missing', async () => {
+    const received = {}
+    const expected = ['repoId', 'remoteUrl']
+
+    assertThat(
+      () => checkForMissingRequestBodyContent({ received, expected }),
+      throws(hasProperty('message', matchesPattern('Missing information from the request'))),
+    )
+  })
+})

--- a/packages/client-adapter-web/src/intercept_request.ts
+++ b/packages/client-adapter-web/src/intercept_request.ts
@@ -1,0 +1,68 @@
+import { Context } from 'koa'
+
+interface CheckForMissingRequestBodyContent {
+  ({ received, expected }: { received: unknown; expected: Array<string> }): void
+}
+
+interface InterceptRequestBody {
+  (ctx: Context, next: () => Promise<void>): void
+}
+
+interface RequestBodyContentHandlers {
+  [key: string]: (received: any) => void
+}
+
+interface ValidateRepoId {
+  (repoId: string): void
+}
+
+const InvalidRepoIdError = Error(
+  'Invalid repoId: We do not expect characters in repoId which must be url encoded.',
+)
+
+const checkForMissingRequestBodyContent: CheckForMissingRequestBodyContent = ({
+  received,
+  expected,
+}) => {
+  const missingRequestBodyContent = expected.filter(
+    (param: string) => !Object.keys(received).includes(param),
+  )
+  if (missingRequestBodyContent.length) {
+    throw Error(`Missing information from the request: ${missingRequestBodyContent.join(', ')}`)
+  }
+}
+
+const validateRepoId: ValidateRepoId = repoId => {
+  if (encodeURIComponent(repoId) !== repoId) {
+    throw InvalidRepoIdError
+  }
+}
+
+const requestBodyContentHandlers: RequestBodyContentHandlers = {
+  'POST/repos': received => {
+    checkForMissingRequestBodyContent({ received, expected: ['repoId', 'remoteUrl'] })
+    validateRepoId(received.repoId)
+  },
+}
+
+const interceptRequestBody: InterceptRequestBody = async (ctx, next) => {
+  const request = ctx.request
+  const handler = requestBodyContentHandlers[`${request.method + request.url}`]
+  if (handler) {
+    try {
+      handler(request.body)
+    } catch (error) {
+      ctx.status = 400
+      ctx.response.body = { error: error.message }
+      return
+    }
+  }
+  await next()
+}
+
+export {
+  interceptRequestBody,
+  validateRepoId,
+  checkForMissingRequestBodyContent,
+  InvalidRepoIdError,
+}

--- a/packages/client-adapter-web/src/repos_router.spec.ts
+++ b/packages/client-adapter-web/src/repos_router.spec.ts
@@ -4,7 +4,7 @@ import { assertThat, equalTo } from 'hamjest'
 import { Server } from 'http'
 import supertest, { SuperTest, Test } from 'supertest'
 import { StubbedInstance, stubInterface } from 'ts-sinon'
-
+import { InvalidRepoIdError } from './intercept_request'
 import WebApp from './web_app'
 import { create } from './repos_router'
 
@@ -73,6 +73,21 @@ describe('/repos', () => {
       app.getInfo.resolves(QueryResult.from())
       app.connectToRemote.withArgs(connectRepoRequest).rejects()
       await request.post('/repos').send(connectRepoRequest).expect(400)
+    })
+
+    it('responds with a message when request body is missing required content', async () => {
+      const connectRepoRequest = {}
+      const response = await request.post('/repos').send(connectRepoRequest).expect(400)
+      assertThat(
+        response.body.error,
+        equalTo('Missing information from the request: repoId, remoteUrl'),
+      )
+    })
+
+    it('responds with a message when repoId is not valid', async () => {
+      const connectRepoRequest = { repoId: 'a/repo/id', remoteUrl: '../tmp' }
+      const response = await request.post('/repos').send(connectRepoRequest).expect(400)
+      assertThat(response.body.error, equalTo(InvalidRepoIdError.message))
     })
   })
 

--- a/packages/client-adapter-web/src/repos_router.ts
+++ b/packages/client-adapter-web/src/repos_router.ts
@@ -1,9 +1,12 @@
 import { Application, ConnectRepoRequest, GitRepoInfo } from 'git-en-boite-client-port'
 import { Context } from 'koa'
 import Router from 'koa-router'
+import { interceptRequestBody } from './intercept_request'
+
 
 export function create(app: Application): Router {
   const router = new Router({ prefix: '/repos' })
+  router.use(interceptRequestBody)
 
   router.get('repo', '/:repoId', async (ctx: Context) => {
     const { repoId } = ctx.params


### PR DESCRIPTION
To check for missing request body items and to validate repoId

Related to issues [26](https://github.com/SmartBear/git-en-boite/issues/26) and [109](https://github.com/SmartBear/git-en-boite/issues/109)
