### PR TITLE
Exists method on local clones

### DIFF
--- a/packages/core/src/git_repo.ts
+++ b/packages/core/src/git_repo.ts
@@ -11,4 +11,5 @@ export interface LocalClone {
 export type LocalClones = {
   openExisting: (path: string) => Promise<LocalClone>
   createNew: (path: string) => Promise<LocalClone>
+  confirmExists: (path: string) => boolean
 }

--- a/packages/inventory/src/inventory_of_repos_on_disk.spec.ts
+++ b/packages/inventory/src/inventory_of_repos_on_disk.spec.ts
@@ -1,4 +1,3 @@
-import fs from 'fs'
 import {
   DomainEventBus,
   InventoryOfRepos,
@@ -19,16 +18,15 @@ import {
   falsey,
 } from 'hamjest'
 import { wasCalled } from 'hamjest-sinon'
+import sinon from 'sinon'
 import { dirSync } from 'tmp'
 import { stubInterface } from 'ts-sinon'
 
 import { InventoryOfReposOnDisk } from './inventory_of_repos_on_disk'
-import { RepoPath } from './repo_path'
 
 describe(InventoryOfReposOnDisk.name, () => {
   let repoId: RepoId
   let basePath: string
-  let repoPath: RepoPath
   let localClones: LocalClones
   let domainEvents: DomainEventBus
   let inventory: InventoryOfRepos
@@ -37,6 +35,7 @@ describe(InventoryOfReposOnDisk.name, () => {
     repoId = RepoId.generate()
     basePath = dirSync().name
     localClones = stubInterface<LocalClones>()
+    localClones.confirmExists = sinon.stub().returns(false)
     domainEvents = stubInterface<DomainEventBus>()
     inventory = new InventoryOfReposOnDisk(basePath, localClones, domainEvents)
   })
@@ -82,8 +81,8 @@ describe(InventoryOfReposOnDisk.name, () => {
 
     context('when the repo already exists', () => {
       beforeEach(() => {
-        repoPath = RepoPath.for(basePath, repoId)
-        fs.mkdirSync(repoPath.value, { recursive: true })
+        localClones.confirmExists = sinon.stub().returns(true)
+        inventory = new InventoryOfReposOnDisk(basePath, localClones, domainEvents)
       })
 
       it(`fails with ${RepoAlreadyExists.name}`, async () => {
@@ -98,8 +97,8 @@ describe(InventoryOfReposOnDisk.name, () => {
   describe('finding existing repos', () => {
     context('when a folder exists for the repo', () => {
       beforeEach(() => {
-        repoPath = RepoPath.for(basePath, repoId)
-        fs.mkdirSync(repoPath.value, { recursive: true })
+        localClones.confirmExists = sinon.stub().returns(true)
+        inventory = new InventoryOfReposOnDisk(basePath, localClones, domainEvents)
       })
 
       it('returns a Repo', async () => {
@@ -122,13 +121,12 @@ describe(InventoryOfReposOnDisk.name, () => {
 
   describe('checking if a repo exists', () => {
     it('returns true if a folder exists for the repo', async () => {
-      repoPath = RepoPath.for(basePath, repoId)
-      fs.mkdirSync(repoPath.value, { recursive: true })
+      localClones.confirmExists = sinon.stub().returns(true)
+      inventory = new InventoryOfReposOnDisk(basePath, localClones, domainEvents)
       assertThat(await inventory.exists(repoId), truthy())
     })
 
     it('returns false if no folder exists for the repo', async () => {
-      repoPath = RepoPath.for(basePath, repoId)
       assertThat(await inventory.exists(repoId), falsey())
     })
   })

--- a/packages/inventory/src/inventory_of_repos_on_disk.ts
+++ b/packages/inventory/src/inventory_of_repos_on_disk.ts
@@ -1,4 +1,3 @@
-import fs from 'fs'
 import {
   LocalClones,
   PublishesDomainEvents,
@@ -10,7 +9,6 @@ import {
   Transaction,
 } from 'git-en-boite-core'
 import { RepoPath } from './repo_path'
-
 export class InventoryOfReposOnDisk implements InventoryOfRepos {
   constructor(
     private basePath: string,
@@ -34,7 +32,6 @@ export class InventoryOfReposOnDisk implements InventoryOfRepos {
 
   public async exists(repoId: RepoId): Promise<boolean> {
     const repoPath = RepoPath.for(this.basePath, repoId).value
-    // TODO: add #exists method to the LocalClones contract and delegate to that instead of using the filesystem
-    return fs.existsSync(repoPath)
+    return this.localClones.confirmExists(repoPath)
   }
 }

--- a/packages/local-clones/src/background_worker_local_clones.ts
+++ b/packages/local-clones/src/background_worker_local_clones.ts
@@ -47,6 +47,10 @@ export class BackgroundWorkerLocalClones implements LocalClones {
     private readonly logger: Logger,
   ) {}
 
+  public confirmExists(path: string): boolean {
+    return this.localClones.confirmExists(path)
+  }
+
   protected async connect(): Promise<BackgroundWorkerLocalClones> {
     this.queueClient = await this.createRedisClient()
     // TODO: pass redisOptions once https://github.com/taskforcesh/bullmq/issues/171 fixed

--- a/packages/local-clones/src/direct_local_clone.ts
+++ b/packages/local-clones/src/direct_local_clone.ts
@@ -15,13 +15,19 @@ import { Commit, Connect, Fetch, GetRefs, Push, RepoProtocol } from './operation
 
 export class DirectLocalClone implements LocalClone {
   static async openExisting(path: string): Promise<LocalClone> {
-    if (!fs.existsSync(path)) throw new Error(`Local clone does not exist at path ${path}`)
+    if (!this.confirmExists(path)) throw new Error(`Local clone does not exist at path ${path}`)
     return new DirectLocalClone(await openBareRepo(path))
   }
 
   static async createNew(path: string): Promise<LocalClone> {
-    if (fs.existsSync(path)) throw new Error(`Local clone already exists at path ${path}`)
+    if (this.confirmExists(path)) {
+      throw new Error(`Local clone already exists at path ${path}`)
+    }
     return new DirectLocalClone(await createBareRepo(path))
+  }
+
+  static confirmExists(path: string): boolean {
+    return fs.existsSync(path)
   }
 
   protected constructor(private readonly git: Dispatch<RepoProtocol>) {}


### PR DESCRIPTION
Hey, referencing [this commit](https://github.com/SmartBear/git-en-boite/commit/d893d1523bd1f1b6e6784d2e5f371b7a430e7109)
Things that were a struggle: 

-Naming the method on LocalClones
-Stubbing, I found it hard to understand the stubInterface, seemed like it can accept methods but was not able to implement so I used sinon  directly.
-Why do we want exists on Inventory to return a promise?

